### PR TITLE
Fixes for failing tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,3 +19,6 @@ LinkingTo: Rcpp, RcppEigen, RcppNumerical
 RoxygenNote: 6.0.1
 Suggests: 
     testthat
+Remotes:
+    jsilve24/driver,
+    mjskay/tidybayes

--- a/tests/testthat/test-main.R
+++ b/tests/testthat/test-main.R
@@ -1,6 +1,5 @@
 context("test-main.R")
 library(driver)
-library(tidyverse)
 set.seed(4)
 
 


### PR DESCRIPTION
The first commit removes the call to `library(tidyverse)` which fixes the tests when using `R CMD check`

The second commit adds the non-CRAN dependencies as Remotes, so they can be installed by `devtools::install_dev_deps()`.