### PR TITLE
Added rudimentary Hessian vector product and line search methods

### DIFF
--- a/src/ConjugateLinearModel.cpp
+++ b/src/ConjugateLinearModel.cpp
@@ -65,6 +65,8 @@ List conjugateLinearModel(const Eigen::Map<Eigen::MatrixXd> Y,
   // // Storage for computation
   MatrixXd LambdaN(D-1, Q);
   MatrixXd XiN(D-1, D-1);
+  MatrixXd temp1(D-1, D-1);
+  MatrixXd temp2(D-1, D-1);
   MatrixXd LambdaDraw(D-1, Q);
   MatrixXd LSigmaDraw(D-1, D-1);
   MatrixXd SigmaDraw(D-1, D-1);
@@ -78,8 +80,11 @@ List conjugateLinearModel(const Eigen::Map<Eigen::MatrixXd> Y,
   LambdaN = Y*XTGammaN+ThetaGammaInvGammaN;
   ELambda = LambdaN-Theta;
   EY = Y-LambdaN*X;
-  XiN = Xi+ EY*EY.transpose() + ELambda*GammaInv*ELambda.transpose();
+  //XiN = Xi+ EY*EY.transpose() + ELambda*GammaInv*ELambda.transpose();
   
+  temp1 = EY*EY.transpose();
+  temp2 = ELambda*GammaInv*ELambda.transpose();
+  XiN = temp1 + Xi + temp2;
   
   // iterate over all draws of eta
   for (int i=0; i < iter; i++){

--- a/tests/testthat/test-hvp.R
+++ b/tests/testthat/test-hvp.R
@@ -1,0 +1,17 @@
+context("test-hessianvectorproduct")
+
+test_that("hessVectorProd output is reasonable", {
+  N <- 20
+  D <- 20
+  sim <- mongrel_sim(D=D, N=N, true_priors=FALSE)
+  Z <- runif(N*(D-1))
+  ThetaX <- sim$Theta%*%sim$X
+  prod1 <- hessMongrelCollapsed(sim$Y, sim$upsilon, ThetaX, sim$K, sim$A, sim$Eta)
+  prod1 <- prod1%*%Z;
+  prod2 <- hessVectorProd(sim$Y, sim$upsilon, ThetaX, sim$K, sim$A, sim$Eta, Z, 0.001)
+  expect_equal(prod1[,1], prod2, tolerance=0.001)
+})
+
+
+
+

--- a/tests/testthat/test-linesearch.R
+++ b/tests/testthat/test-linesearch.R
@@ -1,0 +1,19 @@
+context("test-linesearch")
+
+test_that("linesearch terminates with nonridiculous output", {
+  N <- 20
+  D <- 20
+  sim <- mongrel_sim(D=D, N=N, true_priors=FALSE)
+  Z <- runif(N*(D-1))
+  ThetaX <- sim$Theta%*%sim$X
+  element <- 1
+  new_eta <- lineSearch(sim$Y, sim$upsilon, ThetaX, sim$K, sim$A, sim$Eta, element, 0.5, 0.0001)
+  vec_eta <- c(sim$Eta)
+  compare <- rep(TRUE, N*(D-1))
+  compare[element] <- FALSE
+  expect_equal(vec_eta[compare], new_eta[compare], tolerance=0.0001)
+})
+
+
+
+


### PR DESCRIPTION
Thanks Kim! 

Few points:

1) The changes in ConjugateLinearModel.cpp, I really don't understand why the two temp variables are needed. This also worries me that this "fix" is perhaps hidding a different issue. I am going to instead force eval of the temporal calculated quantities using the *.eval() method in Eigen. This should also ensure these temporary variables hang around for only a minimal time. 

2) Hessian Vector Product looks good! I am going to leave a wrapper in MongrelCollapsed_LGH.cpp but move the bulk of the function into MongrelCollapsed.h as this should enable faster evaluation without having to recreate the objects over and over. I bet this will give us a bigger speed up. 


3) I will have a closer look at the line-search. 

4) Thanks for writing unit tests!

